### PR TITLE
Improve extension load time with a workspace cache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mtbassist",
-  "version": "1.1.12",
+  "version": "1.2.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mtbassist",
-      "version": "1.1.12",
+      "version": "1.2.9",
       "license": "license.txt",
       "dependencies": {
         "@types/json5": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,10 @@
   "contributes": {
     "commands": [
       {
+        "command": "mtbassist.mtbRefreshExtension",
+        "title": "ModusToolbox Assistant: Refresh Extension"
+      },
+      {
         "command": "mtbassist.mtbCreateProject",
         "title": "ModusToolbox Assistant: Create Project"
       },
@@ -52,11 +56,11 @@
       {
         "command": "mtbassist.mtbTurnOnExperimentalNina",
         "title": "ModusToolbox Assistant: Turn On Experimental Ninja Support"
-      },    
+      },
       {
         "command": "mtbassist.mtbTurnOffExperimentalNina",
         "title": "ModusToolbox Assistant: Turn Off Experimental Ninja Support"
-      },         
+      },
       {
         "command": "mtbassist.mtbTurnOnDebugMode",
         "title": "ModusToolbox Assistant: Turn On Debug Mode"

--- a/src/mtbapp/mtbappinfo.ts
+++ b/src/mtbapp/mtbappinfo.ts
@@ -565,7 +565,7 @@ export class MTBAppInfo
     //
     private checkAppType() : Promise<[AppType, Map<string, string>]> {
         let ret : Promise<[AppType, Map<string, string>]> = new Promise<[AppType, Map<string, string>]>((resolve, reject) => {
-            runMakeGetAppInfo(this.appDir)
+            runMakeGetAppInfo(this.appDir, this.context.workspaceState)
                 .then((data : Map<string, string>) => {
                     let dir: string | undefined = data.get(ModusToolboxEnvVarNames.MTB_TOOLS_DIR) ;
                     if (dir) {
@@ -678,7 +678,7 @@ export class MTBAppInfo
                 .then((code: Number) => {
                     if (code === 0) {
                         MTBExtensionInfo.getMtbExtensionInfo().setStatus(StatusType.Loading) ;
-                        runMakeGetAppInfo(cwd)
+                        runMakeGetAppInfo(cwd, this.context.workspaceState)
                             .then((makevars: Map<string, string>) => {
                                 if (!makevars.has(ModusToolboxEnvVarNames.MTB_DEVICE) || makevars.get(ModusToolboxEnvVarNames.MTB_DEVICE)!.length === 0) {
                                     reject(new Error("The ModusToolbox application is not valid, MTB_DEVICE was not supplied")) ;
@@ -784,7 +784,7 @@ export class MTBAppInfo
     private createOneProject(projdir: string) : Promise<void> {
         let ret : Promise<void> = new Promise<void>((resolve, reject) => {
             MTBExtensionInfo.getMtbExtensionInfo().setStatus(StatusType.Loading);
-            runMakeGetAppInfo(projdir)
+            runMakeGetAppInfo(projdir, this.context.workspaceState)
                 .then((makedata: Map<string, string>) => {
                     let projobj = new MTBProjectInfo(this, path.basename(projdir)) ;
                     this.projects.push(projobj) ;
@@ -833,7 +833,7 @@ export class MTBAppInfo
 
     private checkOneProject(projdir: string) : Promise<boolean> {
         let ret : Promise<boolean> = new Promise<boolean>((resolve, reject) => {
-            runMakeGetAppInfo(projdir)
+            runMakeGetAppInfo(projdir, this.context.workspaceState)
             .then((makevars: Map<string, string>) => {
                 if (!makevars.has(ModusToolboxEnvVarNames.MTB_CORE_TYPE) || makevars.get(ModusToolboxEnvVarNames.MTB_CORE_TYPE)!.length === 0) {
                     resolve(true) ;
@@ -1079,7 +1079,7 @@ export class MTBAppInfo
 
     private mtbUpdateProgs() : Promise<void> {
         let ret = new Promise<void>((resolve, reject) => {
-            runMtbLaunch(this.appDir)
+            runMtbLaunch(this.appDir, this.context.workspaceState)
                 .then ((jsonobj: any) => {
                     let obj = this.filterComponents(jsonobj);
                     this.linfo = new MTBLaunchInfo(obj as any) ;

--- a/src/mtbapp/mtbprojinfo.ts
+++ b/src/mtbapp/mtbprojinfo.ts
@@ -95,7 +95,7 @@ export class MTBProjectInfo
 
     public initProject() : Promise<void> {
         return new Promise<void>((resolve, reject) => {
-            runMakeGetAppInfo(this.getProjectDir())
+            runMakeGetAppInfo(this.getProjectDir(), this.app.context.workspaceState)
                 .then((data: Map<string, string>) => {
                     this.initProjectFromData(data)
                         .then(() => {

--- a/src/mtbcommands.ts
+++ b/src/mtbcommands.ts
@@ -416,6 +416,14 @@ function findWorkspaceFile(dir: string) : string  {
     return dir ;
 }
 
+export async function mtbRefreshExtension(context: vscode.ExtensionContext) {
+	for (const key of context.workspaceState.keys()) {
+		console.log("clear: " + key) ; //debug
+		await context.workspaceState.update(key, undefined) ;
+	}
+	vscode.commands.executeCommand("workbench.action.restartExtensionHost", context.extension.id) ;
+}
+
 export function mtbCreateProject(context: vscode.ExtensionContext) {
     if (getModusToolboxApp() !== undefined && getModusToolboxApp()!.isLoading) {
         MTBExtensionInfo.getMtbExtensionInfo().logMessage(MessageType.error, "you must wait for the current ModusToolbox application to finish loading") ;

--- a/src/providers/mtbquicklinkprovider.ts
+++ b/src/providers/mtbquicklinkprovider.ts
@@ -252,9 +252,13 @@ export class MTBQuickLinksProvider implements vscode.TreeDataProvider<MTBAssistI
                     item.command = new MTBAssistCommand(MTBTasks.taskNameQuickProgram, runTaskCmd, name, [ name]) ;
                     app.addChild(item) ;
                 }
+
+                // remove the header if there are no children
+                if (app.getChildren().length == 0) {
+                    this.items_.pop();
+                }
             }
         }
-
         this.onDidChangeTreeData_.fire(undefined) ;
     }
 }


### PR DESCRIPTION
This is just a draft PR so we can discuss...

I did the following:
1. Added workspace caching for load functions that were taking a long time and slowing down the extension loading process.
2. Added an "await" keyword to mbtAssistLoadApp() so that the extension initialization continues to show that it is loading until loading is complete.
3. Added some timers and prints for debug (these should be removed)
4. Added a command to refresh the extension in case the cache gets stale