### PR TITLE
Issue: For combined (single project) applications tasks.json an extraneous tasks.json file generated

### DIFF
--- a/extension/src/extobj/mtbassistobj.ts
+++ b/extension/src/extobj/mtbassistobj.ts
@@ -52,6 +52,7 @@ import { VSCodeAppTaskGenerator } from '../vscodetasks/vscodeapptaskgen';
 import { VSCodeProjTaskGenerator } from '../vscodetasks/vscodeprojtaskgen';
 import { RunTimeTracker } from '../runtime';
 import fetch from 'node-fetch';
+import { ApplicationType } from '../mtbenv/appdata/mtbappinfo';
 
 export class MTBAssistObject {
     private static readonly mtbLaunchUUID = 'f7378c77-8ea8-424b-8a47-7602c3882c49';
@@ -571,10 +572,13 @@ export class MTBAssistObject {
         let gen = new VSCodeAppTaskGenerator(this.env_!, this.settings_) ;
         this.tasks_.set('', new VSCodeTasks(this.logger_, p, gen)) ;
 
-        for(let proj of this.env_!.appInfo!.projects) {
-            p = path.join(this.env_!.appInfo!.appdir, proj.name, '.vscode', 'tasks.json');
-            let pgen = new VSCodeProjTaskGenerator(this.env_!, this.settings_, proj) ;
-            this.tasks_.set(proj.name, new VSCodeTasks(this.logger_, p, pgen)) ;
+        if (this.env_!.appInfo!.type() !== ApplicationType.combined)
+        {
+            for(let proj of this.env_!.appInfo!.projects) {
+                p = path.join(this.env_!.appInfo!.appdir, proj.name, '.vscode', 'tasks.json');
+                let pgen = new VSCodeProjTaskGenerator(this.env_!, this.settings_, proj) ;
+                this.tasks_.set(proj.name, new VSCodeTasks(this.logger_, p, pgen)) ;
+            }
         }
     }
 


### PR DESCRIPTION
Fix: The fix is to no generate project level tasks for application type of combined.

Based on a quick review of the tasks generated by the VSCodeAppTaskGenerator it looks like the erase targets should be valid for the Combined type as well so just dont generate the project level tasks.